### PR TITLE
fix: incorrect prime time

### DIFF
--- a/apps/game-chat/src/components/TopLineMessage.tsx
+++ b/apps/game-chat/src/components/TopLineMessage.tsx
@@ -7,8 +7,8 @@ const formatTime = (hours: number) => {
 
 export function PrimeTimeMessage() {
   const timeInUtc = [
-    { start: 5, end: 6 },
     { start: 11, end: 12 },
+    { start: 16, end: 17 },
   ].map(({ start, end }) => ({
     start: formatTime(start),
     end: formatTime(end),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the displayed prime-time matchmaking hours to reflect new time intervals. The message now shows intervals of 11–12 UTC and 16–17 UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->