### PR TITLE
game-chat: update prime time slots

### DIFF
--- a/apps/game-chat/src/components/TopLineMessage.tsx
+++ b/apps/game-chat/src/components/TopLineMessage.tsx
@@ -8,7 +8,7 @@ const formatTime = (hours: number) => {
 export function PrimeTimeMessage() {
   const timeInUtc = [
     { start: 11, end: 12 },
-    { start: 16, end: 17 },
+    { start: 20, end: 21 },
   ].map(({ start, end }) => ({
     start: formatTime(start),
     end: formatTime(end),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the displayed second prime-time matchmaking hour from 16:00-17:00 UTC to 20:00-21:00 UTC in the matchmaking message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->